### PR TITLE
Support cross building in NIX

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -41,7 +41,7 @@ class JSONCConan(ConanFile):
             host = tools.get_gnu_triplet(str(self.settings.os), str(self.settings.arch))
             tools.replace_in_file(os.path.join(self.source_subfolder, "CMakeLists.txt"),
                                   "execute_process(COMMAND ./configure ",
-                                  "execute_process(COMMAND ./configure --host %s " % host),
+                                  "execute_process(COMMAND ./configure --host %s " % host)
         cmake = CMake(self)
         cmake.configure(build_folder=self.build_subfolder)
         return cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,6 +37,11 @@ class JSONCConan(ConanFile):
         tools.patch(base_path=self.source_subfolder, patch_file="json-c.patch")
 
     def configure_cmake(self):
+        if tools.cross_building(self.settings) and self.settings.os != "Windows":
+            host = tools.get_gnu_triplet(str(self.settings.os), str(self.settings.arch))
+            tools.replace_in_file(os.path.join(self.source_subfolder, "CMakeLists.txt"),
+                                  "execute_process(COMMAND ./configure ",
+                                  "execute_process(COMMAND ./configure --host %s " % host),
         cmake = CMake(self)
         cmake.configure(build_folder=self.build_subfolder)
         return cmake


### PR DESCRIPTION
Hi, I was trying to cross build the library for ARM and it complains because the configure (that is called from CMake) has to be invoked with a `--host`. 